### PR TITLE
Change go.mod, main.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,3 @@
 module backend
 
 go 1.15
-
-require internal/verses v1.0.0
-replace internal/verses => ./internal/verses
-
-require internal/commands v1.0.0
-replace internal/commands => ./internal/commands

--- a/main.go
+++ b/main.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"internal/verses"
-	"internal/commands"
 	"fmt"
+
+	"./internal/commands"
+	"./internal/verses"
 )
 
 func main() {
-	verses.Router();
-	commands.Router();
-	fmt.Printf("Hello world.");
+	verses.Router()
+	commands.Router()
+	fmt.Printf("Hello world.")
 }


### PR DESCRIPTION
So I ran `go get github.com/BibleBot/Backend` and got two errors:
```
package internal/commands: unrecognized import path "internal/commands": import path does not begin with hostname
package internal/verses: unrecognized import path "internal/verses": import path does not begin with hostname
```

So I think it's be best to remove the `require`  and `replace` stuff in `go.mod`, and instead just import those packages locally in `main.go`, prefixing them with `./`:
```go
import (
	"fmt"

	"./internal/commands" // <--
	"./internal/verses" // <--
)
```

I also removed the semicolons from the statements in `main()`, lines don't have to end in a semicolon, unless you want to separate multiple statements on one line.